### PR TITLE
Update README

### DIFF
--- a/.storybook/preset.ts
+++ b/.storybook/preset.ts
@@ -1,6 +1,6 @@
-import type { Indexer } from '@storybook/core/types';
-import { loadCsf } from '@storybook/core/csf-tools';
-import { serverRequire } from '@storybook/core/common';
+import type { Indexer } from 'storybook/internal/types';
+import { loadCsf } from 'storybook/internal/csf-tools';
+import { serverRequire } from 'storybook/internal/common';
 import { compile } from './compile';
 import { vite, webpack, STORIES_REGEX } from './unplugin';
 

--- a/.storybook/unplugin.ts
+++ b/.storybook/unplugin.ts
@@ -1,5 +1,5 @@
 import { createUnplugin } from 'unplugin';
-import { serverRequire } from '@storybook/core/common';
+import { serverRequire } from 'storybook/internal/common';
 import { compile, CompileOptions } from './compile';
 
 export const STORIES_REGEX = /\.dynamic\.[tj]sx?/;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
-![image](https://user-images.githubusercontent.com/3481514/145904252-92e3dc1e-591f-410f-88a1-b4250f4ba6f2.png)
+# React Native Screenshots
 
-## Taking image snapshots of Storybook
+This demonstrates how to screenshot React Native (RN) from a mobile simulator and test them in Chromatic.
+
+It consists of the following:
+
+1. **RN storybook**. The "main" Storybook, configured by the `.rnstorybook` config dir.
+2. **Snapshot script**. A script, `snapshot-storybook.ts`, that navigates to every story in the running RN storybook and dumps a snapshot into the `snapshots` directory.
+3. **Snapshot storybook**. A second Storybook, configured by the `.storybook` config dir, that renders images from the `screenshots` directory as stories, so that Chromatic can process them.
+4. **Github action**. A Github action workflow that runs on MacOS and executes the snapshot script to populate the `screenshots` directory.
+
+![architecture](https://github.com/user-attachments/assets/504588df-4e56-404c-b550-a76c967df079)
+
+## Running locally
 
 Screenshotting your RN app requires a few steps:
 
@@ -15,3 +26,30 @@ EXPO_PUBLIC_STORYBOOK_SNAPSHOT=true npm run storybook:ios
 ```sh
 npm run snapshot-storybook
 ```
+
+3. View the screenshot Storybook to see the results as they will be sent to Chromatic.
+
+```sh
+npm run storybook:web
+```
+
+## Running in CI
+
+Running in CI requires a built application binary:
+
+```sh
+build.sh
+```
+
+This generates the file `AwesomeStorybook.tar.gz`, which is consumed by the CI script.
+In this prototype, we are doing this by hand and checking it into Git for our own convenience
+
+We assume that real-world RN projects are already building binaries as part of their CI workflow
+and that you would update the scripts to consume those instead of the hard-coded build shown here.
+
+## Known limitations
+
+The prototype has the following known limitations, none of which are fundamental to the approach:
+
+- [ ] When running locally, writing a snapshot to the file system causes the simulator to refresh, which messes up the next snapshot in the list. This is not a problem in CI because we are running against the built application, and not in dev mode. To fix this, we need to figure out how to get RN to ignore the `screenshots` directory.
+- [ ] Lack of story-level Chromatic configuration. Chromatic can be configured in various ways, e.g. to skip stories, or even to ignore regions within a story. This prototype would need to be extended to add these features.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "storybook": "expo start --dev-client",
     "storybook:ios": "expo start --dev-client --ios",
     "storybook:android": "expo start --dev-client --android",
-    "snapshot-storybook": "tsx storybook-testing.ts",
+    "snapshot-storybook": "tsx snapshot-storybook.ts",
     "build:screenshot:ios:local": "eas build --profile screenshot --platform ios --local",
     "build:screenshot:android:local": "eas build --profile screenshot --platform android --local",
     "build:ios": "bash ./build.sh",

--- a/snapshot-storybook.ts
+++ b/snapshot-storybook.ts
@@ -5,7 +5,7 @@ import { execSync } from 'child_process';
 import { buildIndex } from 'storybook/internal/core-server';
 import { WebSocketServer } from 'ws';
 
-async function doEverything() {
+async function snapshotStorybook() {
   const secured = false;
   const host = 'localhost';
   const port = 7007;
@@ -69,7 +69,7 @@ async function doEverything() {
   const sleep = (ms: number) =>
     new Promise((resolve) => setTimeout(resolve, ms));
 
-  async function GoThroughAllStories() {
+  async function snapshotAllStories() {
     // wait 500ms for storybook to start?
     await sleep(1000);
 
@@ -92,7 +92,7 @@ async function doEverything() {
 
   // channel.once(Events.STORY_RENDERED, () => {
   console.log('Going through all stories');
-  GoThroughAllStories()
+  snapshotAllStories()
     .then(() => {
       exec(
         'xcrun simctl terminate booted com.chromatic.awesomestorybook || true',
@@ -111,4 +111,4 @@ async function doEverything() {
   // });
 }
 
-doEverything();
+snapshotStorybook();


### PR DESCRIPTION
### Storybook Configuration Updates:
* Updated imports in `.storybook/preset.ts` and `.storybook/unplugin.ts` to use `storybook/internal` for 9.0. [[1]](diffhunk://#diff-158158ddd1b0c2d6c1f793f95f3b7faed4d6246d8b840c87f51943f9fb4cb48dL1-R3) [[2]](diffhunk://#diff-4e066ecfed857919414563a4c5a7e3051e473bf89199ca5d709b02ba4a18c278L2-R2)

### Documentation Enhancements:
* Expanded `README.md` to include detailed instructions for running React Native screenshot workflows locally and in CI, along with an architecture diagram and known limitations. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R14) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R29-R55)

### Script Updates:
* Renamed `storybook-testing.ts` to `snapshot-storybook.ts` for clarity, and updated function names (`doEverything` → `snapshotStorybook`, `GoThroughAllStories` → `snapshotAllStories`) to better reflect their purpose. [[1]](diffhunk://#diff-31d2ee4c783ed8941b3db421b101a79e99cf47add0d466bbbca07c3f29f32a53L8-R8) [[2]](diffhunk://#diff-31d2ee4c783ed8941b3db421b101a79e99cf47add0d466bbbca07c3f29f32a53L72-R72) [[3]](diffhunk://#diff-31d2ee4c783ed8941b3db421b101a79e99cf47add0d466bbbca07c3f29f32a53L95-R95) [[4]](diffhunk://#diff-31d2ee4c783ed8941b3db421b101a79e99cf47add0d466bbbca07c3f29f32a53L114-R114)